### PR TITLE
Fix Insight Room in Cable Club

### DIFF
--- a/Plugins/Cable Club/[001] Cable Club Client/003_Battle_CableClub.rb
+++ b/Plugins/Cable Club/[001] Cable Club Client/003_Battle_CableClub.rb
@@ -367,7 +367,7 @@ class PokeBattle_CableClub_AI < PokeBattle_AI
                   @battle.choices[their_index][1] = record.int
                   move = record.nil_or(:bool)
                   if move
-                    move = (@battle.choices[their_index][1]<0) ? @battle.struggle : partner_pkmn.moves[@battle.choices[their_index][1]]
+                    move = (@battle.choices[their_index][1]<0) ? @battle.struggle : partner_pkmn.getMoves[@battle.choices[their_index][1]]
                   end
                   @battle.choices[their_index][2] = move
                   @battle.choices[their_index][3] = record.int


### PR DESCRIPTION
When determining which move the opponent used, index into the getMoves getter instead of the unmodified @moves array which doesn't include the insight room move