### PR TITLE
Abilities that proc when being hit changed

### DIFF
--- a/PBS/abilities.txt
+++ b/PBS/abilities.txt
@@ -153,7 +153,7 @@ Description = Reduces damage from super-effective attacks by 25%.
 #-------------------------------
 [FLAMEBODY]
 Name = Flame Body
-Description = Physical moves against the Pokémon have a 30% chance to burn the attacker.
+Description = Boosts Defense by 20%. When the Pokémon takes its second physical hit from a foe, they become burned.
 #-------------------------------
 [FLOWERGIFT]
 Name = Flower Gift
@@ -370,7 +370,7 @@ Flags = SetupCounterAI
 #-------------------------------
 [POISONPOINT]
 Name = Poison Point
-Description = Physical attacks against the Pokémon have a 30% chance to poison the attacker.
+Description = Boosts Defense by 20%. When the Pokémon takes its second physical hit from a foe, they become poisoned.
 #-------------------------------
 [POISONTOUCH]
 Name = Poison Touch
@@ -539,7 +539,7 @@ Flags = Immutable
 #-------------------------------
 [STATIC]
 Name = Static
-Description = Physical attacks against the Pokémon have a 30% chance to cause numbing.
+Description = Boosts Defense by 20%. When the Pokémon takes its second physical hit from a foe, they become numbed.
 #-------------------------------
 [STEELWORKER]
 Name = Steelworker

--- a/PBS/abilities_new.txt
+++ b/PBS/abilities_new.txt
@@ -126,7 +126,7 @@ Description = Healing on the Pokémon is reversed.
 #-------------------------------
 [BACKWASH]
 Name = Backwash
-Description = Special attacks against the Pokémon have a 30% chance to waterlog the attacker.
+Description = Boosts Sp. Def by 20%. When the Pokémon takes its second special hit from a foe, they become waterlogged.
 #-------------------------------
 [BADINFLUENCE]
 Name = Bad Influence
@@ -162,7 +162,7 @@ Description = Boosts power of light-based moves by 30%.
 #-------------------------------
 [BEGUILING]
 Name = Beguiling
-Description = Special attacks against the Pokémon have a 30% chance to dizzy the attacker.
+Description = Boosts Sp. Def by 20%. When the Pokémon takes its second special hit from a foe, they become dizzied.
 #-------------------------------
 [BELLOWER]
 Name = Bellower
@@ -279,7 +279,7 @@ Description = Immune to Fighting-type moves, and raises Attack and Sp. Atk if hi
 #-------------------------------
 [CHILLEDBODY]
 Name = Chilled Body
-Description = Physical moves against the Pokémon have a 30% chance to frostbite the attacker.
+Description = Boosts Defense by 20%. When the Pokémon takes its second physical hit from a foe, they become frostbitten.
 #-------------------------------
 [CHILLOUT]
 Name = Chill Out
@@ -366,7 +366,7 @@ Description = When hit with a special move, hits back instantly with Breach.
 #-------------------------------
 [CURSEDTAIL]
 Name = Cursed Tail
-Description = When a foe hits the Pokémon, they are warned. If they do it again, they become cursed.
+Description = Boosts Defense and Sp. Def by 20%. When a foe hits the Pokémon, they are warned. If they do it again, they become cursed.
 #-------------------------------
 [CYNIC]
 Name = Cynic
@@ -461,7 +461,7 @@ Description = On the first turn, its attacks numb the target.
 #-------------------------------
 [DISORIENTING]
 Name = Disorienting
-Description = Physical attacks against the Pokémon have a 30% chance to dizzy the attacker.
+Description = Boosts Defense by 20%. When the Pokémon takes its second physical hit from a foe, they become dizzied.
 #-------------------------------
 [DOMINATING]
 Name = Dominating
@@ -663,7 +663,7 @@ Description = The Pokémon is also Fire-type.
 #-------------------------------
 [FIERYSPIRIT]
 Name = Fiery Spirit
-Description = Special moves against the Pokémon have a 30% chance to burn the attacker.
+Description = Boosts Sp. Def by 20%. When the Pokémon takes its second special hit from a foe, they become burned.
 #-------------------------------
 [FIGHTINGVIGOR]
 Name = Fighting Vigor
@@ -1104,7 +1104,7 @@ Description = If an attack lowers the Pokémon's HP to half or less, the attacke
 #-------------------------------
 [KELPLINK]
 Name = Kelp Link
-Description = Physical moves against the Pokémon have a 30% chance to leech the attacker.
+Description = Boosts Defense by 20%. When the Pokémon takes its second physical hit from a foe, they become leeched.
 #-------------------------------
 [KICKBACK]
 Name = Kickback
@@ -1470,7 +1470,7 @@ Description = While the Pokémon is below half health, its attacks leech those h
 #-------------------------------
 [PETRIFYING]
 Name = Petrifying
-Description = Special attacks against the Pokémon have a 30% chance to cause numbing.
+Description = Boosts Sp. Def by 20%. When the Pokémon takes its second special hit from a foe, they become numbed.
 #-------------------------------
 [PETTY]
 Name = Petty
@@ -1515,7 +1515,7 @@ Description = Immune to Poison-type moves and restores 25% of max HP if hit by o
 #-------------------------------
 [POISONPUNISH]
 Name = Poison Punish
-Description = Special attacks against the Pokémon have a 30% chance to poison the attacker.
+Description = Boosts Sp. Def by 20%. When the Pokémon takes its second special hit from a foe, they become poisoned.
 #-------------------------------
 [POLARIZING]
 Name = Polarizing
@@ -1540,7 +1540,7 @@ Description = Deals 25% more damage per stockpile.
 #-------------------------------
 [PUNISHER]
 Name = Punisher
-Description = Special moves against the Pokémon have a 30% chance to leech the attacker.
+Description = Boosts Sp. Def by 20%. When the Pokémon takes its second special hit from a foe, they become leeched.
 #-------------------------------
 [PUREENERGY]
 Name = Pure Energy
@@ -1874,7 +1874,7 @@ Flags = MoonglowSynergy
 #-------------------------------
 [SOPPING]
 Name = Sopping
-Description = Physical attacks against the Pokémon have a 30% chance to waterlog the attacker.
+Description = Boosts Defense by 20%. When the Pokémon takes its second physical hit from a foe, they become waterlogged.
 #-------------------------------
 [SPACEINTERLOPER]
 Name = Space Interloper
@@ -2012,7 +2012,7 @@ Description = Powers up Ice-type moves by 50%.
 #-------------------------------
 [SUDDENCHILL]
 Name = Sudden Chill
-Description = Special moves against the Pokémon have a 30% chance to frostbite the attacker.
+Description = Boosts Sp. Def by 20%. When the Pokémon takes its second special hit from a foe, they become frostbitten.
 #-------------------------------
 [SUDDENTURN]
 Name = Sudden Turn

--- a/Plugins/Tectonic Battle/Abilities/Ability Event Handlers/Defending stats/DefenseCalcUserAbilities.rb
+++ b/Plugins/Tectonic Battle/Abilities/Ability Event Handlers/Defending stats/DefenseCalcUserAbilities.rb
@@ -39,3 +39,59 @@ BattleHandlers::DefenseCalcUserAbility.add(:SAFEPASSAGE,
         next defenseMult
     }
 )
+
+BattleHandlers::DefenseCalcUserAbility.add(:STATIC,
+    proc { |ability, _user, _battle, defenseMult|
+        defenseMult *= 1.2
+        next defenseMult
+    }
+)
+
+BattleHandlers::DefenseCalcUserAbility.add(:POISONPOINT,
+    proc { |ability, _user, _battle, defenseMult|
+        defenseMult *= 1.2
+        next defenseMult
+    }
+)
+
+BattleHandlers::DefenseCalcUserAbility.add(:FLAMEBODY,
+    proc { |ability, _user, _battle, defenseMult|
+        defenseMult *= 1.2
+        next defenseMult
+    }
+)
+
+BattleHandlers::DefenseCalcUserAbility.add(:CHILLEDBODY,
+    proc { |ability, _user, _battle, defenseMult|
+        defenseMult *= 1.2
+        next defenseMult
+    }
+)
+
+BattleHandlers::DefenseCalcUserAbility.add(:DISORIENT,
+    proc { |ability, _user, _battle, defenseMult|
+        defenseMult *= 1.2
+        next defenseMult
+    }
+)
+
+BattleHandlers::DefenseCalcUserAbility.add(:KELPLINK,
+    proc { |ability, _user, _battle, defenseMult|
+        defenseMult *= 1.2
+        next defenseMult
+    }
+)
+
+BattleHandlers::DefenseCalcUserAbility.add(:SOPPING,
+    proc { |ability, _user, _battle, defenseMult|
+        defenseMult *= 1.2
+        next defenseMult
+    }
+)
+
+BattleHandlers::DefenseCalcUserAbility.add(:CURSEDTAIL,
+    proc { |ability, _user, _battle, defenseMult|
+        defenseMult *= 1.2
+        next defenseMult
+    }
+)

--- a/Plugins/Tectonic Battle/Abilities/Ability Event Handlers/Defending stats/SpecialDefenseCalcUserAbilities.rb
+++ b/Plugins/Tectonic Battle/Abilities/Ability Event Handlers/Defending stats/SpecialDefenseCalcUserAbilities.rb
@@ -60,3 +60,59 @@ BattleHandlers::SpecialDefenseCalcUserAbility.add(:ICEMIRROR,
         next spDefMult
     }
 )
+
+BattleHandlers::SpecialDefenseCalcUserAbility.add(:PETRIFYING,
+    proc { |ability, _user, _battle, spDefMult|
+        spDefMult *= 1.2
+        next spDefMult
+    }
+)
+
+BattleHandlers::SpecialDefenseCalcUserAbility.add(:POISONPUNISH,
+    proc { |ability, _user, _battle, spDefMult|
+        spDefMult *= 1.2
+        next spDefMult
+    }
+)
+
+BattleHandlers::SpecialDefenseCalcUserAbility.add(:FIERYSPIRIT,
+    proc { |ability, _user, _battle, spDefMult|
+        spDefMult *= 1.2
+        next spDefMult
+    }
+)
+
+BattleHandlers::SpecialDefenseCalcUserAbility.add(:SUDDENCHILL,
+    proc { |ability, _user, _battle, spDefMult|
+        spDefMult *= 1.2
+        next spDefMult
+    }
+)
+
+BattleHandlers::SpecialDefenseCalcUserAbility.add(:BEGUILING,
+    proc { |ability, _user, _battle, spDefMult|
+        spDefMult *= 1.2
+        next spDefMult
+    }
+)
+
+BattleHandlers::SpecialDefenseCalcUserAbility.add(:PUNISHER,
+    proc { |ability, _user, _battle, spDefMult|
+        spDefMult *= 1.2
+        next spDefMult
+    }
+)
+
+BattleHandlers::SpecialDefenseCalcUserAbility.add(:BACKWASH,
+    proc { |ability, _user, _battle, spDefMult|
+        spDefMult *= 1.2
+        next spDefMult
+    }
+)
+
+BattleHandlers::SpecialDefenseCalcUserAbility.add(:CURSEDTAIL,
+    proc { |ability, _user, _battle, spDefMult|
+        spDefMult *= 1.2
+        next spDefMult
+    }
+)

--- a/Plugins/Tectonic Battle/Abilities/Ability Event Handlers/On Hit/TargetAbilitiesOnHit.rb
+++ b/Plugins/Tectonic Battle/Abilities/Ability Event Handlers/On Hit/TargetAbilitiesOnHit.rb
@@ -394,18 +394,43 @@ BattleHandlers::TargetAbilityOnHit.add(:LOUDSLEEPER,
 #########################################
 # Numb inducing abilities
 #########################################
-
 BattleHandlers::TargetAbilityOnHit.add(:STATIC,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.physicalMove?
-        randomStatusProcTargetAbility(ability, :NUMB, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+        randomStatusProcTargetAbility(ability, :NUMB, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
-  
+
 BattleHandlers::TargetAbilityOnHit.add(:PETRIFYING,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.specialMove?
-        randomStatusProcTargetAbility(ability, :NUMB, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+        randomStatusProcTargetAbility(ability, :NUMB, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
@@ -415,14 +440,40 @@ BattleHandlers::TargetAbilityOnHit.add(:PETRIFYING,
 BattleHandlers::TargetAbilityOnHit.add(:POISONPOINT,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.physicalMove?
-        randomStatusProcTargetAbility(ability, :POISON, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+        randomStatusProcTargetAbility(ability, :POISON, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
-  )
+)
 
 BattleHandlers::TargetAbilityOnHit.add(:POISONPUNISH,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.specialMove?
-        randomStatusProcTargetAbility(ability, :POISON, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+        randomStatusProcTargetAbility(ability, :POISON, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
@@ -432,14 +483,40 @@ BattleHandlers::TargetAbilityOnHit.add(:POISONPUNISH,
 BattleHandlers::TargetAbilityOnHit.add(:FLAMEBODY,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.physicalMove?
-        randomStatusProcTargetAbility(ability, :BURN, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+        randomStatusProcTargetAbility(ability, :BURN, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
 BattleHandlers::TargetAbilityOnHit.add(:FIERYSPIRIT,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.specialMove?
-        randomStatusProcTargetAbility(ability, :BURN, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+        randomStatusProcTargetAbility(ability, :BURN, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
@@ -449,14 +526,40 @@ BattleHandlers::TargetAbilityOnHit.add(:FIERYSPIRIT,
 BattleHandlers::TargetAbilityOnHit.add(:CHILLEDBODY,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.physicalMove?
-        randomStatusProcTargetAbility(ability, :FROSTBITE, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+            randomStatusProcTargetAbility(ability, :FROSTBITE, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
 BattleHandlers::TargetAbilityOnHit.add(:SUDDENCHILL,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.specialMove?
-        randomStatusProcTargetAbility(ability, :FROSTBITE, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+        randomStatusProcTargetAbility(ability, :FROSTBITE, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
@@ -466,14 +569,40 @@ BattleHandlers::TargetAbilityOnHit.add(:SUDDENCHILL,
 BattleHandlers::TargetAbilityOnHit.add(:DISORIENT,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.physicalMove?
-        randomStatusProcTargetAbility(ability, :DIZZY, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+            randomStatusProcTargetAbility(ability, :DIZZY, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
 BattleHandlers::TargetAbilityOnHit.add(:BEGUILING,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.specialMove?
-        randomStatusProcTargetAbility(ability, :DIZZY, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+            randomStatusProcTargetAbility(ability, :DIZZY, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
@@ -483,14 +612,40 @@ BattleHandlers::TargetAbilityOnHit.add(:BEGUILING,
 BattleHandlers::TargetAbilityOnHit.add(:KELPLINK,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.physicalMove?
-        randomStatusProcTargetAbility(ability, :LEECHED, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+            randomStatusProcTargetAbility(ability, :LEECHED, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
 BattleHandlers::TargetAbilityOnHit.add(:PUNISHER,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.specialMove?
-        randomStatusProcTargetAbility(ability, :LEECHED, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+            randomStatusProcTargetAbility(ability, :LEECHED, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
@@ -500,14 +655,40 @@ BattleHandlers::TargetAbilityOnHit.add(:PUNISHER,
 BattleHandlers::TargetAbilityOnHit.add(:SOPPING,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.physicalMove?
-        randomStatusProcTargetAbility(ability, :WATERLOG, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+            randomStatusProcTargetAbility(ability, :WATERLOG, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 
 BattleHandlers::TargetAbilityOnHit.add(:BACKWASH,
     proc { |ability, user, target, move, battle, aiCheck, aiNumHits|
         next unless move.specialMove?
-        randomStatusProcTargetAbility(ability, :WATERLOG, 30, user, target, move, battle, aiCheck, aiNumHits)
+        if aiCheck
+            if user.effectActive?(:Warned) || aiNumHits > 1
+                next -30
+            else
+                next -10
+            end
+        end
+        battle.pbShowAbilitySplash(target, ability)
+        if user.effectActive?(:Warned)
+            randomStatusProcTargetAbility(ability, :WATERLOG, 100, user, target, move, battle, aiCheck, aiNumHits)
+        else
+            user.applyEffect(:Warned)
+        end
+        battle.pbHideAbilitySplash(target)
     }
 )
 


### PR DESCRIPTION
The following abilities now have a 100% chance to proc when hit a second time by the same Pokemon, and boosts the related defense by 20%. CURSEDTAIL has both defenses boosted. STATIC
PETRIFYING
POISONPOINT
POISONPUNISH
FLAMEBODY
FIERYSPIRIT
CHILLEDBODY
SUDDENCHILL
DISORIENT
BEGUILING
KELPLINK
PUNISHER
SOPPING
BACKWASH